### PR TITLE
fix: update package.json to fix Typescript error TS7016

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "module": "dist/esm/single-spa-vue.js",
   "exports": {
     ".": {
+      "types": "./types/single-spa-vue.d.ts",
       "import": "./dist/esm/single-spa-vue.js",
       "require": "./dist/umd/single-spa-vue.js"
     },


### PR DESCRIPTION


The fix involves adding a `types` property to the `exports` property in the `package.json` file, with the same value as the main `types` property used in the same file.